### PR TITLE
fix: exit early on unsafe NTFS state to prevent accidental reinstall

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -351,19 +351,14 @@ is_windows_installed() {
   MOUNT_LOG=$(mount.ntfs "$WIN_PATH" "$WIN_MOUNT_FOLDER" 2>&1)
 
   # check for unclean NTFS mount (hibernated/Fast Startup) warning 
-  echo "$MOUNT_LOG" | grep -q "unclean file system"
-  if [ $? -eq 0 ]; then
+  if echo "$MOUNT_LOG" | grep -q "unclean file system"; then
     print_exit
-    print_centered "NTFS is in an unsafe state! boot to Windows and"
-    nl_print_centered "Please disable Fast Startup and shutdown Windows properly."
-    return 1
+    print_centered "NTFS is in an unsafe state! Boot into Windows and"
+    nl_print_centered "disable Fast Startup, then shutdown Windows properly."
+    exit 1
   fi
 
-  if [ -f "$WIN_MOUNT_FOLDER/Windows/explorer.exe" ]; then
-    return 0
-  else
-    return 1
-  fi
+  [ -f "$WIN_MOUNT_FOLDER/Windows/explorer.exe" ]
 }
 
 is_partition_rw() { touch "$WIN_MOUNT_FOLDER/rw_test" 2>/dev/null && rm "$WIN_MOUNT_FOLDER/rw_test"; }


### PR DESCRIPTION
The function used "return 1" but since its return value wasn't checked before continuing, the script proceeded into the reinstall logic anyways, replaced with "exit 1" to explicitly terminate the script