### PR TITLE
Fix typos

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -172,8 +172,8 @@ navigate_menu() {
   count=${#options[@]}
   selection=0
   print_line
-  print_centered "Use Volume down to selcect/change the options,"
-  print_centered "Use Volume up to select and confirm"
+  print_centered "Use volume down to selcect/change the options,"
+  print_centered "Use volume up to select and confirm"
   print_line
   while true; do
     ui_print " "
@@ -205,10 +205,10 @@ volumekey_timeout() {
   kill -0 $pid 2>/dev/null && kill $pid 2>/dev/null
   grep VOLUME "$UPD_TEMP_FOLDER/raw_events" | grep " DOWN" > "$UPD_TEMP_FOLDER/events"
   if grep -q "VOLUMEUP" "$UPD_TEMP_FOLDER/events"; then
-    echo "Volume Up detected" >> "$UPD_TEMP_FOLDER/debug.log"
+    echo "Volume up detected" >> "$UPD_TEMP_FOLDER/debug.log"
     return 1
   elif grep -q "VOLUMEDOWN" "$UPD_TEMP_FOLDER/events"; then
-    echo "Volume Down detected" >> "$UPD_TEMP_FOLDER/debug.log"
+    echo "Volume down detected" >> "$UPD_TEMP_FOLDER/debug.log"
     return 0
   fi
   echo "No key detected" >> "$UPD_TEMP_FOLDER/debug.log"
@@ -224,8 +224,8 @@ navigate_menu_timeout() {
   last_selection=-1
   last_countdown=-1
   print_line
-  print_centered "Use Volume down to select/change options"
-  print_centered "Use Volume up to confirm"
+  print_centered "Use volume down to select/change options"
+  print_centered "Use volume up to confirm"
   print_centered "Auto-confirm in $timeout_duration seconds..."
   print_line
   ui_print " "
@@ -285,7 +285,7 @@ verify_device() {
   current="$(getprop ro.product.device)"
   if [ "$current" != "$DEVICE_CODE" ]; then
     print_exit
-    print_centered "This script is only for $DEVICE_CODE devices."
+    print_centered "This script is only for $DEVICE_CODE "
     nl_print_centered "Your device is: $current"
     exit 1
   fi
@@ -296,7 +296,7 @@ round() { awk "BEGIN {print int($1 + 0.5)}"; }
 verify_part() {
   UD_PATH="$BASE_PATH/userdata" # Userdata partition block name (same for all devices)
   if [ ! -e "$WIN_PATH" ] || [ ! -e "$ESP_PATH" ]; then
-    abort "Required partition ($WIN_PATH and/or $ESP_PATH) do not exist."
+    abort "Required partition(s) ($WIN_PATH and/or $ESP_PATH) do not exist."
   fi
   local UD_GB=$(awk "BEGIN {print $(blockdev --getsize64 "$UD_PATH") / 1e9}")
   local WIN_GB=$(awk "BEGIN {print $(blockdev --getsize64 "$WIN_PATH") / 1e9}")
@@ -308,7 +308,7 @@ verify_part() {
   print_centered "ESP Size: ${ESP_R}MB"
   print_centered "Windows Size: ${WIN_R}GB"
   if [ "$WIN_R" -ge "$WIN_MIN_SIZE" ] && [ "$ESP_R" -ge "$ESP_MIN_SIZE" ]; then
-    print_centered "Partition verifyied & meets requirements"
+    print_centered "Partitions verified & meets requirements"
   else
     #ui_print "*----------------------Note!---------------------*"
     print_exit
@@ -446,9 +446,9 @@ check_file_and_hash() {
 	    print_exit
         print_centered " File: $file_path not found in package!"
         print_line -
-        print_centered "Your download zip might be corrupted." 
+        print_centered "Your WinInstaller zip might be corrupt." 
         print_centered "Please download again and retry."
-        nl_print_centered "if Still same, Post a screenshot in the group."
+        nl_print_centered "if the error remains, post a screenshot in the Telegram group."
         exit 1
     fi
     local actual_hash
@@ -462,9 +462,9 @@ check_file_and_hash() {
         print_centered "current file Got:"
         print_centered "$actual_hash"
         print_line -
-        ln_print_centered "Your download zip might be corrupted." 
+        ln_print_centered "Your WinInstaller zip might be corrupt." 
         print_centered "Please download again and retry."
-        nl_print_centered "if Still same, Post a screenshot in the group."
+        nl_print_centered "if the error remains, post a screenshot in the Telegram group."
         exit 1
     fi
     #ui_print "SHA-1 verification passed for $file_path"
@@ -478,9 +478,9 @@ mkdir -p "$WIN_MOUNT_FOLDER"
 
 package_extract_file "wininstaller.conf" "$CONFIG_FILE" || {
     ui_print " "
-    ui_print " Error: Wininstaller Configuration file not found or empty"
+    ui_print " Error: Wininstaller configuration file not found or empty"
     ui_print " " 
-    ui_print " Make sure you have a file (wininstaller.conf) in main directory with all configration"
+    ui_print " Make sure you have the file (wininstaller.conf) in main directory with all configrations"
     ui_print " " 
     exit 1
 }

--- a/META-INF/com/google/android/updater-script
+++ b/META-INF/com/google/android/updater-script
@@ -14,23 +14,23 @@ source "$CONFIG_FILE"
 #       along with a timeout mechanism for user selections
 
 print_line = # Prints a banner line using CHAR_WIDTH length of '-' (or custom character), wrapped with '*' on both ends
-print_centered "Welcome to Windows Installation on $DEVICE_NAME"
+print_centered "Welcome to WinInstaller for $DEVICE_NAME"
 print_centered "Version: $WI_VERSION"
-print_centered "Build Date: $BUID_DATE"
+print_centered "Build date: $BUILD_DATE"
 print_centered "Made by: Kumar_Jy & ArKT"
 print_centered "Help and suggestions by: Sog, Andre_grams"
 print_centered "Drivers & UEFI: $MAINTAINER"
 print_line =
 verify_device
 aio_progress 0.5 10   # start progress from 0% to 50% in 10 seconds
-print_centered "Verifying files integrity and checks"
+print_centered "Verifying file integrity"
 file_checksum
-print_centered "files Verifications Done"
+print_centered "File verification done"
 print_line
-print_centered "Verifying required Partitions"
+print_centered "Verifying required partitions"
 verify_part
 print_line # Prints a banner line using CHAR_WIDTH length of '-' (or custom character), wrapped with '*' on both ends
-print_centered "Checking Battery Status"
+print_centered "Checking battery status"
 if verify_battery; then
 print_centered "Battery percentage is sufficient: $CURRENT_BATTERY%"
 else
@@ -51,18 +51,18 @@ if is_windows_installed; then
 print_centered "Windows is already installed"
 print_line
 aio_progress 0.5 0    # instantly moves progress back to 50% (for reset or rewind)
-winask=("Option 1: Driver Update/install only" "Option 2: Windows re-install (with format)")
+winask=("Option 1: Driver update/install only" "Option 2: Windows re-install (with format)")
 navigate_menu_timeout "${winask[@]}"
 case "$selection" in
   0)
     if is_partition_rw; then
     print_line
     print_centered "Skipping format and copy steps"
-    print_centered "and processing for Drivers Installation"
+    print_centered "and processing for driver installation"
     else
     print_exit
-    print_centered "Error: Partition is Read-Only"
-    nl_print_centered "Goto Windows then reboot to Android and try again"
+    print_centered "Error: Partition is read-only"
+    nl_print_centered "Go to Windows then reboot into Android and try again"
     umount "$WIN_PATH"
     exit 1
     fi
@@ -74,10 +74,10 @@ case "$selection" in
     print_centered "You chose to reinstall Windows"
     print_centered "Proceeding with formatting and installation"
     print_line
-    print_centered "Searching for Windows Image"
+    print_centered "Searching for Windows image (.wim or .esd)"
     win_esd_search
     print_line
-    print_centered "Verifying Windows Edition"
+    print_centered "Verifying Windows edition"
     find_index
     print_line
     print_centered "Installing $SELECTED_EDITION...."
@@ -88,13 +88,13 @@ case "$selection" in
 else
 aio_progress 0.5 0    # instantly moves progress back to 5% (for reset or rewind)
 aio_progress 0.9 80   # moves progress from 5% to 90% in 80 seconds
-print_centered "Windows is not already installed"
-print_centered "Proceeding with Windows Installation"
+print_centered "Windows is not yet installed"
+print_centered "Proceeding with Windows installation"
 print_line
-print_centered "Searching for Windows Image"
+print_centered "Searching for Windows image"
 win_esd_search
 print_line
-print_centered "Verifying Windows Edition"
+print_centered "Verifying Windows edition"
 find_index
 print_line
 print_centered "Installing $SELECTED_EDITION...."
@@ -103,7 +103,7 @@ format_win
 fi
 if ! is_windows_installed; then
 print_exit
-print_centered "$SELECTED_EDITION Fail to install "
+print_centered "$SELECTED_EDITION Failed to install "
 print_centered "ESD/WIM file may be corrupted..."
 nl_print_centered "Reboot to Android and check the ESD/WIM file."
 umount "$WIN_PATH"
@@ -114,7 +114,7 @@ fi
 aio_progress 0.5 0    # instantly moves progress back to 50% (for reset or rewind)
 aio_progress 0.95 50  # moves progress from 50% to 95% in 50 seconds
 print_line
-print_centered "Extracting Installation File";
+print_centered "Extracting installation files";
 package_extract_folder "installer" "$WIN_MOUNT_FOLDER"
 for var in ESP_PART_NAME DEVICE_NAME WI_VERSION BUID_DATE SECURE_BOOT MAINTAINER; do
   eval value=\$$var
@@ -133,11 +133,11 @@ dd if="$WIN_MOUNT_FOLDER/installer/uefi.img" of="$BASE_PATH/boot$(getprop ro.boo
 umount "$WIN_PATH" "$ESP_PATH"
 sleep 1
 print_line =
-print_centered "Flashing Completed, Now reboot to system"
+print_centered "Flashing completed, now press "Reboot system""
 print_centered "Installation will start automatically"
 print_line =
-print_centered "If it fails, Don't Flash it again"
-print_centered "ask for help on Telegram: @wininstaller"
+print_centered "If it fails, don't flash it again"
+print_centered "Ask for help on Telegram: @wininstaller"
 print_centered "Thanks to all WOA Developers & Maintainers"
 print_line =
 exitask=("Option 1: Reboot device" "Option 2: Exit")
@@ -145,14 +145,14 @@ navigate_menu_timeout "${exitask[@]}"
 case "$selection" in
   0)
     print_line
-    print_centered "your device will reboot now!"
+    print_centered "Your device will reboot now!"
     print_line
     sleep 1
 	  reboot
     ;;
   1)
     print_line
-    print_centered "WinInstaller nuked done!"
+    print_centered "WinInstaller nuke done!"
     print_line
     exit
     ;;

--- a/installer/install.bat
+++ b/installer/install.bat
@@ -20,7 +20,7 @@ mode 800
 :: wininstaller.conf variables
 set ESP_PART_NAME=
 set WI_VERSION=
-set BUID_DATE=
+set BUILD_DATE=
 set DEVICE_NAME=
 set SECURE_BOOT=
 set MAINTAINER=
@@ -28,7 +28,7 @@ echo(
 echo ============================================================
 echo        Welcome to Windows Installation in %DEVICE_NAME%    
 echo              Version: %WI_VERSION%              
-echo              Date   : %BUID_DATE%                           
+echo              Date   : %BUILD_DATE%                           
 echo              Made by: Kumar_Jy, ArKT                             
 echo          Help and suggestions: Sog, Andre_grams.        
 echo    Drivers And UEFI: %MAINTAINER%
@@ -49,7 +49,7 @@ if exist "%~d0\Windows\explorer.exe" (
     echo Windows is already installed.
     goto formatAndAssign
 ) else (
-    echo windows not installed
+    echo Windows not installed
     goto fail
 )
 


### PR DESCRIPTION
I couldn't find the "croupted" typo of Vayu WinInstaller, so I assume it is from a chage that wasn't implemented in the main repo